### PR TITLE
Support subscribing to a subscription server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ script:
   - cd Build
   - make test
   - ctest -T Memcheck
-  - cat Testing/Temporary/MemoryChecker.*.log
+  - cat Testing/Temporary/*.log
   - cd ..
   - ./CMakeUtils/travis/doCoverage.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,12 +24,14 @@ add_library(CPPWebSocketResponseRequest STATIC
     include/io_thread.h
     include/stream_client.h
     include/IOneShotConnectionConsumer.h
+    include/OpenConnections.h
     src/io_thread.cpp
     src/ReqFileList.cpp
     src/ReqServer.cpp
     src/ReqSvrRequest.cpp
     src/WebPPSingleThreadOneShotClient.cpp
     src/stream_client.cpp
+    src/OpenConnections.cpp
 )
 target_link_libraries(CPPWebSocketResponseRequest PUBLIC
     FixedJSON::FixedJSON
@@ -55,6 +57,7 @@ set_property(TARGET CPPWebSocketResponseRequest PROPERTY PUBLIC_HEADER
     ${CPPWebSocketResponseRequest_SOURCE_DIR}/include/io_thread.h
     ${CPPWebSocketResponseRequest_SOURCE_DIR}/include/stream_client.h
     ${CPPWebSocketResponseRequest_SOURCE_DIR}/include/IOneShotConnectionConsumer.h
+    ${CPPWebSocketResponseRequest_SOURCE_DIR}/include/OpenConnections.h
 )
 
 #
@@ -65,8 +68,12 @@ find_package(GTest REQUIRED)
 add_executable(requestReply test/requestReply.cpp)
 target_link_libraries(requestReply CPPWebSocketResponseRequest GTest::GTest)
 
+add_executable(sub test/sub.cpp)
+target_link_libraries(sub CPPWebSocketResponseRequest GTest::GTest)
+
 enable_testing()
 add_test(requestReply requestReply)
+add_test(sub sub)
 
 #
 # NOTE: Valgrind must be configured *before* testing is imported

--- a/include/OpenConnections.h
+++ b/include/OpenConnections.h
@@ -1,0 +1,14 @@
+#ifndef CPPWEBSOCKETRESPONSEREQUEST_OPENCONNECTIONS_H
+#define CPPWEBSOCKETRESPONSEREQUEST_OPENCONNECTIONS_H
+#include <ReqServer.h>
+
+class OpenConnectionsList {
+public:
+    void Add(SubscriptionHandler::RequestHandle hdl);
+
+    void Publish(const std::string& msg);
+private:
+    std::vector<SubscriptionHandler::RequestHandle> hdls;
+};
+
+#endif //CPPWEBSOCKETRESPONSEREQUEST_OPENCONNECTIONS_H

--- a/include/ReqServer.h
+++ b/include/ReqServer.h
@@ -140,6 +140,7 @@ private:
      * Bail out of the event loop...
      */
     void Stop();
+    void StopNoBlock();
 
     std::string HandleRequestReplyMessage(
                     const std::string& reqName,
@@ -178,6 +179,7 @@ private:
             return (raw < rhs.raw);
         }
     };
+    std::mutex mapGuard;
     std::map<StoredHdl,SubscriptionHandler::RequestHandle> conn_map;
 
     // Error tracking

--- a/include/ReqServer.h
+++ b/include/ReqServer.h
@@ -89,9 +89,8 @@ public:
              const std::string& requestName, 
              std::unique_ptr<RequestReplyHandler> handler);
 
-    void AddHandler(
-             const std::string& requestName, 
-             std::unique_ptr<SubscriptionHandler> handler);
+    void AddHandler( const std::string& requestName,
+                     std::shared_ptr<SubscriptionHandler> handler);
 
     /**
      * Run the event loop, handle any incoming requests or posted tasks
@@ -162,12 +161,24 @@ private:
     std::future<bool>  stopped;
 
     std::map<std::string,std::unique_ptr<RequestReplyHandler>> req_handlers;
-    std::map<std::string,std::unique_ptr<SubscriptionHandler>> sub_handlers;
+    std::map<std::string,std::shared_ptr<SubscriptionHandler>> sub_handlers;
 
     /*
      * Maps an active connection to
      */
-    std::map<void*,SubscriptionHandler::RequestHandle> conn_map;
+    struct StoredHdl{
+        StoredHdl(websocketpp::connection_hdl hdl)
+           : raw(hdl.lock().get())
+           , hdl(hdl) {}
+
+        void * raw;
+        websocketpp::connection_hdl hdl;
+
+        bool operator<(const StoredHdl& rhs) const {
+            return (raw < rhs.raw);
+        }
+    };
+    std::map<StoredHdl,SubscriptionHandler::RequestHandle> conn_map;
 
     // Error tracking
     bool        failed;

--- a/include/io_thread.h
+++ b/include/io_thread.h
@@ -1,7 +1,6 @@
 #ifndef DEV_TOOLS_CPP_LIBS_WEBSOCKETS_IO_THREAD_H__
 #define DEV_TOOLS_CPP_LIBS_WEBSOCKETS_IO_THREAD_H__
 
-#include <stream_client.h>
 #include <boost/asio.hpp>
 #include <memory>
 #include <thread>

--- a/include/stream_client.h
+++ b/include/stream_client.h
@@ -39,6 +39,10 @@ public:
      */
     bool WaitUntilRunning();
 
+    void Ping(unsigned int timeout);
+
+    struct InvalidUrlException {};
+
 protected: 
     /**
      * Run the event loop - (start the query)
@@ -49,6 +53,7 @@ protected:
      * Stop the event loop
      */
     void Stop();
+    void StopNonBlock();
     
     /**
      * Call-back triggered when a new message is received.
@@ -62,14 +67,16 @@ private:
 
 
     /**
-     * Call-back to notify us of a successful connection
-     */
-    void on_open(websocketpp::connection_hdl hdl);
-
-    /**
      * Call-back to notify us of a successful subscription connection
      */
     void on_sub_open(websocketpp::connection_hdl hdl);
+
+    /**
+     * Call-back to notify us of a close event
+     */
+    void on_close(websocketpp::connection_hdl hdl);
+
+    void on_pong_timeout(websocketpp::connection_hdl hdl, std::string msg);
 
     /**
      * Call-back triggered by the arrival of a new message

--- a/include/stream_client.h
+++ b/include/stream_client.h
@@ -72,10 +72,8 @@ private:
     void on_sub_open(websocketpp::connection_hdl hdl);
 
     /**
-     * Call-back to notify us of a close event
+     * Call-back when a ping request has timed out
      */
-    void on_close(websocketpp::connection_hdl hdl);
-
     void on_pong_timeout(websocketpp::connection_hdl hdl, std::string msg);
 
     /**

--- a/src/OpenConnections.cpp
+++ b/src/OpenConnections.cpp
@@ -1,0 +1,19 @@
+#include <OpenConnections.h>
+#include <OpenConnections.h>
+
+void OpenConnectionsList::Add(SubscriptionHandler::RequestHandle hdl) {
+    hdls.emplace_back(hdl);
+}
+
+void OpenConnectionsList::Publish(const std::string &msg) {
+    std::vector<SubscriptionHandler::RequestHandle> newHdls;
+    newHdls.reserve(hdls.size());
+    for (auto& hdl: hdls) {
+        if (hdl->Ok()) {
+            hdl->SendMessage(msg);
+            newHdls.emplace_back(std::move(hdl));
+        }
+    }
+
+    hdls = std::move(newHdls);
+}

--- a/src/stream_client.cpp
+++ b/src/stream_client.cpp
@@ -1,6 +1,8 @@
 #include "stream_client.h"
 
 #include <iostream>
+#include <stream_client.h>
+
 
 using websocketpp::lib::placeholders::_1;
 using websocketpp::lib::placeholders::_2;
@@ -8,83 +10,82 @@ using websocketpp::lib::bind;
 
 typedef websocketpp::client<websocketpp::config::asio_tls_client> client;
 typedef websocketpp::lib::shared_ptr<boost::asio::ssl::context> context_ptr;
-typedef client::connection_ptr connection_ptr;
 
 using namespace std;
 
-StreamClientThread::StreamClientThread(const std::string& url)
-   : StreamClient(url),
-     io_thread([=] () -> void { this->Run(); })
+StreamClient::StreamClient(std::string url, std::string subName, std::string subBody)
+        : running(false)
+        , con(nullptr)
+        , subName(std::move(subName))
+        , subBody(std::move(subBody))
+        , url(std::move(url))
+        , futureStart(startFlag.get_future())
+        , futureStop(stopFlag.get_future())
 {
-}
-
-StreamClientThread::~StreamClientThread()
-{
-    Stop();
-    io_thread.join();
-}
-
-StreamClient::StreamClient(const std::string& url) 
-   : running(false), con(nullptr)
-{
-    m_endpoint.set_access_channels(websocketpp::log::alevel::all);
+    m_endpoint.clear_access_channels(websocketpp::log::alevel::all);
     m_endpoint.set_error_channels(websocketpp::log::elevel::all);
 
     // Initialize ASIO
     m_endpoint.init_asio();
 
     // Register our handlers
-    m_endpoint.set_tls_init_handler(bind(&StreamClient::on_tls_init,this,::_1));
     m_endpoint.set_message_handler(bind(&StreamClient::on_message,this,::_1,::_2));
-    m_endpoint.set_open_handler(bind(&StreamClient::on_open,this,::_1));
-
-    websocketpp::lib::error_code ec;
-    con = m_endpoint.get_connection(url, ec);
-
-    if (ec) {
-        m_endpoint.get_alog().write(websocketpp::log::alevel::app,ec.message());
-    }
-
-    m_endpoint.connect(con);
-}
-
-context_ptr StreamClient::on_tls_init(websocketpp::connection_hdl) {
-    typedef boost::asio::ssl::context context;
-
-    context_ptr ctx = 
-        websocketpp::lib::make_shared<context>(context::tlsv1);
-
-    try {
-        ctx->set_options(context::default_workarounds);
-    } catch (std::exception& e) {
-        std::cout << "TLS Failure: " << std::endl;
-        std::cout << e.what() << std::endl;
-    }
-
-    return ctx;
+    m_endpoint.set_open_handler(bind(&StreamClient::on_sub_open,this,::_1));
 }
 
 void StreamClient::on_open(websocketpp::connection_hdl hdl) {
     m_endpoint.send(hdl, "", websocketpp::frame::opcode::text);
 }
 
-void StreamClient::on_message(websocketpp::connection_hdl hdl, message_ptr msg) 
+void StreamClient::on_sub_open(websocketpp::connection_hdl hdl) {
+    m_endpoint.send(hdl, subName + " " + subBody, websocketpp::frame::opcode::text);
+}
+
+void StreamClient::on_message(websocketpp::connection_hdl hdl, message_ptr msg)
 {
     OnMessage(msg->get_payload());
 }
 
 void StreamClient::Run() {
     running = true;
-    m_endpoint.run();
+    startFlag.set_value(true);
+    websocketpp::lib::error_code ec;
+    con = m_endpoint.get_connection(url, ec);
+
+    if (ec) {
+        std::cout << "Failed to connect [" << url << "]"
+                  << ": " << ec.message() << std::endl;
+    } else {
+        m_endpoint.connect(con);
+        m_endpoint.run();
+    }
+    stopFlag.set_value(true);
     running = false;
 }
 
 void StreamClient::Stop() {
     if ( Running() && con.get() ) {
-        m_endpoint.close(con,websocketpp::close::status::going_away,"");
+        websocketpp::lib::error_code ec;
+        m_endpoint.close(con,websocketpp::close::status::going_away,"", ec);
+    }
+    m_endpoint.get_io_service().stop();
+    m_endpoint.get_io_service().reset();
+
+    if (Running() ) {
+        futureStop.get();
     }
 }
 
 bool StreamClient::Running() {
     return running;
 }
+
+bool StreamClient::WaitUntilRunning() {
+    return futureStart.get();
+}
+
+
+StreamClient::~StreamClient() {
+    this->Stop();
+}
+

--- a/src/stream_client.cpp
+++ b/src/stream_client.cpp
@@ -31,17 +31,11 @@ StreamClient::StreamClient(std::string url, std::string subName, std::string sub
     // Register our handlers
     m_endpoint.set_message_handler(bind(&StreamClient::on_message,this,::_1,::_2));
     m_endpoint.set_open_handler(bind(&StreamClient::on_sub_open,this,::_1));
-    m_endpoint.set_close_handler(bind(&StreamClient::on_close,this,::_1));
     m_endpoint.set_pong_timeout_handler(bind(&StreamClient::on_pong_timeout,this, ::_1, ::_2));
-    m_endpoint.set_fail_handler(bind(&StreamClient::on_close,this,::_1));
 }
 
 void StreamClient::on_sub_open(websocketpp::connection_hdl hdl) {
     m_endpoint.send(hdl, subName + " " + subBody, websocketpp::frame::opcode::text);
-}
-
-void StreamClient::on_close(websocketpp::connection_hdl hdl) {
-    m_endpoint.stop();
 }
 
 void StreamClient::on_message(websocketpp::connection_hdl hdl, message_ptr msg)

--- a/src/stream_client.cpp
+++ b/src/stream_client.cpp
@@ -67,12 +67,10 @@ void StreamClient::Stop() {
     if ( Running() && con.get() ) {
         websocketpp::lib::error_code ec;
         m_endpoint.close(con,websocketpp::close::status::going_away,"", ec);
+        futureStop.get();
     }
-    m_endpoint.get_io_service().stop();
-    m_endpoint.get_io_service().reset();
 
     if (Running() ) {
-        futureStop.get();
     }
 }
 

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -1,0 +1,269 @@
+#include "gtest/gtest.h"
+
+#include "WorkerThread.h"
+#include "ReqServer.h"
+#include "io_thread.h"
+#include <PipePublisher.h>
+#include <stream_client.h>
+#include <OpenConnections.h>
+
+const size_t serverPort = 1250;
+const std::string serverUri = "ws://localhost:1250";
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+class TestHandler: public SubscriptionHandler
+{
+public:
+    static constexpr const char* SUB_TYPE = "SUB_Echo_Test";
+
+    void OnRequest(RequestHandle hdl) override {
+        hdl->SendMessage(hdl->RequestMessasge());
+        hdls.Add(std::move(hdl));
+    }
+
+    void Publish(const std::string& message) {
+        hdls.Publish(message);
+    }
+
+    static std::shared_ptr<TestHandler> New() {
+        return std::make_unique<TestHandler>();
+    }
+
+    OpenConnectionsList hdls;
+};
+
+class ClientPublisher: public StreamClient {
+public:
+    ClientPublisher(std::string url, std::string subName, std::string body)
+        : StreamClient(std::move(url), std::move(subName), std::move(body)) {}
+
+    void OnMessage(const std::string& msg) override {
+        publisher.Publish(msg);
+    }
+
+    std::shared_ptr<PipeSubscriber<std::string>> NewClient() {
+        return publisher.NewClient(1000);
+    }
+
+    void Start() {
+        Run();
+    }
+
+    using StreamClient::Stop;
+private:
+    PipePublisher<std::string> publisher;
+};
+
+class SubTest: public ::testing::Test {
+public:
+    SubTest()
+       : clientPub(serverUri, TestHandler::SUB_TYPE, "Hello World!")
+    {
+        handler = TestHandler::New();
+        messages = clientPub.NewClient();
+    }
+    void SetUp() {
+
+        server.AddHandler(TestHandler::SUB_TYPE, handler);
+        // Request server's main loop is blocking, start up on a slave thread...
+        serverThread.PostTask([&] () -> void {
+            server.HandleRequests(serverPort);
+        });
+        serverThread.Start();
+
+        // wait for the server to spin up...
+        server.WaitUntilRunning();
+
+        messages = clientPub.NewClient();
+        clientThread.PostTask([&] () -> void {
+            clientPub.Start();
+        });
+        clientThread.Start();
+        clientPub.WaitUntilRunning();
+
+        std::string message;
+        ASSERT_TRUE(messages->WaitForMessage(message));
+
+        ASSERT_EQ(message, "Hello World!");
+    }
+
+    void TearDown () {
+        clientPub.Stop();
+        clientThread.DoTask([=] () -> void {
+        });
+    }
+protected:
+    std::shared_ptr<TestHandler> handler;
+    WorkerThread           serverThread;
+    RequestServer          server;
+    WorkerThread           clientThread;
+    ClientPublisher        clientPub;
+
+    std::shared_ptr<PipeSubscriber<std::string>> messages;
+};
+
+TEST_F(SubTest, NewMessage) {
+    const std::string message = "New Message to send";
+    handler->Publish(message);
+
+    std::string got;
+    messages->WaitForMessage(got);
+    ASSERT_EQ(message, got);
+}
+
+TEST_F(SubTest, AbortedClient) {
+    clientPub.Stop();
+    const std::string message = "New Message to send";
+    handler->Publish(message);
+
+    std::string got;
+    ASSERT_FALSE(messages->GetNextMessage(got));
+}
+
+class SubTestSecondClient: public SubTest {
+public:
+    SubTestSecondClient()
+       : SubTest()
+       , clientPub2(serverUri, TestHandler::SUB_TYPE, logonMsg)
+    {}
+
+    void SetUp() override {
+        SubTest::SetUp();
+
+        messages2 = clientPub2.NewClient();
+        clientThread2.PostTask([&] () -> void {
+            clientPub2.Start();
+        });
+        clientThread2.Start();
+        clientPub2.WaitUntilRunning();
+
+        std::string got;
+        messages2->WaitForMessage(got);
+        ASSERT_EQ(logonMsg, got);
+
+        // But don't publish to the original...
+        ASSERT_FALSE(messages->GetNextMessage(got));
+
+    }
+
+    void TearDown() override {
+        SubTest::TearDown();
+        clientPub2.Stop();
+        clientThread2.DoTask([=] () -> void {
+        });
+    }
+protected:
+    const std::string      logonMsg;
+    WorkerThread           clientThread2;
+    ClientPublisher        clientPub2;
+    std::shared_ptr<PipeSubscriber<std::string>> messages2;
+};
+
+TEST_F(SubTestSecondClient, NewMessage) {
+    const std::string message = "New Message to send";
+    handler->Publish(message);
+
+    std::string got;
+    ASSERT_TRUE(messages->WaitForMessage(got));
+    ASSERT_EQ(message, got);
+
+    ASSERT_TRUE(messages2->WaitForMessage(got));
+    ASSERT_EQ(message, got);
+}
+
+TEST_F(SubTestSecondClient, AbortedClient) {
+    // Kill only the first client
+    clientPub.Stop();
+
+    const std::string message = "New Message to send";
+    handler->Publish(message);
+
+    std::string got;
+    ASSERT_TRUE(messages2->WaitForMessage(got));
+    ASSERT_EQ(message, got);
+
+    ASSERT_FALSE(messages->GetNextMessage(got));
+}
+
+class SubTestThirdClient: public SubTestSecondClient {
+public:
+    SubTestThirdClient()
+            : SubTestSecondClient()
+            , clientPub3(serverUri, TestHandler::SUB_TYPE, logonMsg3)
+    {}
+
+    void SetUp() override {
+        SubTestSecondClient::SetUp();
+
+        messages3 = clientPub3.NewClient();
+        clientThread3.PostTask([&] () -> void {
+            clientPub3.Start();
+        });
+        clientThread3.Start();
+        clientPub3.WaitUntilRunning();
+
+        std::string got;
+        messages3->WaitForMessage(got);
+        ASSERT_EQ(logonMsg, got);
+
+        // But don't publish to the original...
+        ASSERT_FALSE(messages->GetNextMessage(got));
+
+    }
+
+    void TearDown() override {
+        SubTestSecondClient::TearDown();
+        clientPub3.Stop();
+        clientThread3.DoTask([=] () -> void {
+        });
+    }
+protected:
+    const std::string      logonMsg3;
+    WorkerThread           clientThread3;
+    ClientPublisher        clientPub3;
+    std::shared_ptr<PipeSubscriber<std::string>> messages3;
+};
+
+TEST_F(SubTestThirdClient, NewMessage) {
+    const std::string message = "New Message to send";
+    handler->Publish(message);
+
+    std::string got;
+    ASSERT_TRUE(messages->WaitForMessage(got));
+    ASSERT_EQ(message, got);
+
+    ASSERT_TRUE(messages2->WaitForMessage(got));
+    ASSERT_EQ(message, got);
+
+    ASSERT_TRUE(messages3->WaitForMessage(got));
+    ASSERT_EQ(message, got);
+}
+
+TEST_F(SubTestThirdClient, AbortedClient) {
+    clientPub2.Stop();
+    const std::string message = "New Message to send";
+    handler->Publish(message);
+
+    std::string got;
+    ASSERT_TRUE(messages->WaitForMessage(got));
+    ASSERT_EQ(message, got);
+
+    ASSERT_TRUE(messages3->WaitForMessage(got));
+    ASSERT_EQ(message, got);
+
+    ASSERT_FALSE(messages2->GetNextMessage(got));
+
+    const std::string message2 = "Post publish message";
+    handler->Publish(message2);
+    ASSERT_TRUE(messages->WaitForMessage(got));
+    ASSERT_EQ(message2, got);
+
+    ASSERT_TRUE(messages3->WaitForMessage(got));
+    ASSERT_EQ(message2, got);
+
+    ASSERT_FALSE(messages2->GetNextMessage(got));
+}

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -122,6 +122,9 @@ TEST_F(SubTest, NewMessage) {
 
 TEST_F(SubTest, AbortedClient) {
     clientPub.Stop();
+    clientThread.DoTask([] () -> void {
+        // flush...
+    });
     const std::string message = "New Message to send";
     handler->Publish(message);
 
@@ -339,5 +342,5 @@ TEST_F(SubErrorTest, EarlyServerAbort) {
     Time timeout;
 
     ASSERT_GE(timeout.DiffUSecs(start), 100 * 1000);
-    ASSERT_LE(timeout.DiffUSecs(start), 101 * 1000);
+    ASSERT_LE(timeout.DiffUSecs(start), 200 * 1000);
 }

--- a/test/sub.cpp
+++ b/test/sub.cpp
@@ -92,9 +92,11 @@ public:
     }
 
     void TearDown () {
-        clientPub.Stop();
-        clientThread.DoTask([=] () -> void {
-        });
+        if (clientPub.Running()) {
+            clientPub.Stop();
+            clientThread.DoTask([=] () -> void {
+            });
+        }
     }
 protected:
     std::shared_ptr<TestHandler> handler;
@@ -152,9 +154,11 @@ public:
 
     void TearDown() override {
         SubTest::TearDown();
-        clientPub2.Stop();
-        clientThread2.DoTask([=] () -> void {
-        });
+        if (clientPub2.Running()) {
+            clientPub2.Stop();
+            clientThread2.DoTask([=] () -> void {
+            });
+        }
     }
 protected:
     const std::string      logonMsg;
@@ -217,9 +221,11 @@ public:
 
     void TearDown() override {
         SubTestSecondClient::TearDown();
-        clientPub3.Stop();
-        clientThread3.DoTask([=] () -> void {
-        });
+        if (clientPub3.Running()) {
+            clientPub3.Stop();
+            clientThread3.DoTask([=] () -> void {
+            });
+        }
     }
 protected:
     const std::string      logonMsg3;


### PR DESCRIPTION
The stream_client has been cleaned up:
   - Remove the old (insecure) TLS "support"
   - Support for sending an initial message (requried to hook into
     subscriptions)

In addition tests hav been added to validate the behaviour of the
subcription server/ client, and some memory issues have been resolved