### PR TITLE
Stop leaking boost into the global namespace #13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(CPPWebSocketResponseRequest STATIC
     include/IOneShotConnectionConsumer.h
     include/OpenConnections.h
     include/ClientUtils.h
+    include/CPPWSRRWraper.h
     src/io_thread.cpp
     src/ReqFileList.cpp
     src/ReqServer.cpp
@@ -33,7 +34,9 @@ add_library(CPPWebSocketResponseRequest STATIC
     src/WebPPSingleThreadOneShotClient.cpp
     src/stream_client.cpp
     src/OpenConnections.cpp
-    src/ClientUtils.cpp)
+    src/ClientUtils.cpp
+    src/Wraper.cpp
+    src/WebSocketPP.h)
 
 target_link_libraries(CPPWebSocketResponseRequest PUBLIC
     FixedJSON::FixedJSON
@@ -50,6 +53,8 @@ target_include_directories(CPPWebSocketResponseRequest PUBLIC
     $<BUILD_INTERFACE:${CPPWebSocketResponseRequest_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
+target_compile_features(CPPWebSocketResponseRequest PRIVATE cxx_std_20)
+
 
 set_property(TARGET CPPWebSocketResponseRequest PROPERTY PUBLIC_HEADER
     ${CPPWebSocketResponseRequest_SOURCE_DIR}/include/ReqFileList.h
@@ -60,6 +65,7 @@ set_property(TARGET CPPWebSocketResponseRequest PROPERTY PUBLIC_HEADER
     ${CPPWebSocketResponseRequest_SOURCE_DIR}/include/stream_client.h
     ${CPPWebSocketResponseRequest_SOURCE_DIR}/include/IOneShotConnectionConsumer.h
     ${CPPWebSocketResponseRequest_SOURCE_DIR}/include/OpenConnections.h
+    ${CPPWebSocketResponseRequest_SOURCE_DIR}/include/CPPWSRRWraper.h
 )
 
 add_executable(req src/req.cpp)

--- a/include/CPPWSRRWraper.h
+++ b/include/CPPWSRRWraper.h
@@ -1,0 +1,44 @@
+//
+// Created by lhumphreys on 11/09/2020.
+//
+
+#ifndef CPPWEBSOCKETRESPONSEREQUEST_WRAPER_H
+#define CPPWEBSOCKETRESPONSEREQUEST_WRAPER_H
+
+#include <memory>
+
+struct Server {
+    Server();
+    virtual ~Server();
+    void* underlying;
+
+    Server(const Server& rhs ) = delete;
+    Server(Server&& rhs ) = delete;
+    Server& operator=(const Server& rhs) = delete;
+    Server& operator=(Server&& rhs) = delete;
+};
+
+struct IOService {
+    IOService();
+    virtual ~IOService();
+    void* underlying;
+
+    IOService(const IOService& rhs ) = delete;
+    IOService(IOService&& rhs ) = delete;
+    IOService& operator=(const IOService& rhs) = delete;
+    IOService& operator=(IOService&& rhs) = delete;
+};
+
+struct ASIOClient {
+    ASIOClient();
+    virtual ~ASIOClient();
+    void* underlying;
+
+    using ConnPtr = std::shared_ptr<void>;
+};
+
+struct ConnectHdl {
+    std::weak_ptr<void> hdl;
+};
+
+#endif //CPPWEBSOCKETRESPONSEREQUEST_WRAPER_H

--- a/include/ReqServer.h
+++ b/include/ReqServer.h
@@ -5,9 +5,8 @@
 #include <map>
 #include <memory>
 
-#include <websocketpp/config/asio_no_tls.hpp>
-#include <websocketpp/server.hpp>
 #include <IPostable.h>
+#include <CPPWSRRWraper.h>
 
 class RequestReplyHandler {
 public:
@@ -64,8 +63,6 @@ public:
     virtual void OnRequest(RequestHandle hdl) = 0;
 };
 
-typedef websocketpp::server<websocketpp::config::asio> Server;
-
 /**
  *  The request server 
  */
@@ -114,7 +111,7 @@ public:
     std::string HandleMessage(
          const std::string& request,
          Server*  raw_server,
-         websocketpp::connection_hdl hdl);
+         ConnectHdl hdl);
 
     /**
      * Blocks until the request server's is up, and the event loop is running.
@@ -125,7 +122,7 @@ public:
     /**
      * Handle an on_close even on an active connection.
      */
-    void HandleClose(websocketpp::connection_hdl hdl);
+    void HandleClose(ConnectHdl hdl);
 
     struct FatalErrorException {
         int code;
@@ -152,7 +149,7 @@ private:
                     const std::string& request,
                     SubscriptionHandler& handler,
                     Server*  raw_server,
-                    websocketpp::connection_hdl hdl);
+                    ConnectHdl hdl);
 
 
     Server requestServer_;
@@ -168,12 +165,12 @@ private:
      * Maps an active connection to
      */
     struct StoredHdl{
-        StoredHdl(websocketpp::connection_hdl hdl)
-           : raw(hdl.lock().get())
+        StoredHdl(ConnectHdl hdl)
+           : raw(hdl.hdl.lock().get())
            , hdl(hdl) {}
 
         void * raw;
-        websocketpp::connection_hdl hdl;
+        ConnectHdl hdl;
 
         bool operator<(const StoredHdl& rhs) const {
             return (raw < rhs.raw);

--- a/include/io_thread.h
+++ b/include/io_thread.h
@@ -1,7 +1,6 @@
 #ifndef DEV_TOOLS_CPP_LIBS_WEBSOCKETS_IO_THREAD_H__
 #define DEV_TOOLS_CPP_LIBS_WEBSOCKETS_IO_THREAD_H__
 
-#include <boost/asio.hpp>
 #include <memory>
 #include <thread>
 #include <condition_variable>
@@ -46,7 +45,7 @@ private:
      */
     void Stop();
 
-    boost::asio::io_service io_service;
+    IOService io_service;
     std::thread io_thread;
     WebPPSingleThreadOneShotClient requestClient;
 };

--- a/include/stream_client.h
+++ b/include/stream_client.h
@@ -1,12 +1,10 @@
 #ifndef DEV_TOOLS_CPP_LIBS_WEBSOCKETS_STREAM_CLIENT_H__
 #define DEV_TOOLS_CPP_LIBS_WEBSOCKETS_STREAM_CLIENT_H__
 
-#include <websocketpp/config/asio_client.hpp>
-
-#include <websocketpp/client.hpp>
 #include <atomic>
 #include <thread>
 #include <future>
+#include <CPPWSRRWraper.h>
 
 /**
  * Subscribes to a websocket and triggers a call-back for each message.
@@ -43,6 +41,16 @@ public:
 
     struct InvalidUrlException {};
 
+    /**
+     * Call-back triggered when a new message is received.
+     *
+     * NOTE: This call-back is triggered from the IO thread.
+     */
+    virtual void OnMessage(const std::string& msg) = 0;
+
+    // TODO: Make protected again
+    void StopNonBlock();
+
 protected: 
     /**
      * Run the event loop - (start the query)
@@ -53,46 +61,19 @@ protected:
      * Stop the event loop
      */
     void Stop();
-    void StopNonBlock();
-    
-    /**
-     * Call-back triggered when a new message is received.
-     *
-     * NOTE: This call-back is triggered from the IO thread.
-     */
-    virtual void OnMessage(const std::string& msg) = 0;
 
 private:
-    typedef websocketpp::config::asio_tls_client::message_type::ptr message_ptr;
-
-
-    /**
-     * Call-back to notify us of a successful subscription connection
-     */
-    void on_sub_open(websocketpp::connection_hdl hdl);
-
-    /**
-     * Call-back when a ping request has timed out
-     */
-    void on_pong_timeout(websocketpp::connection_hdl hdl, std::string msg);
-
-    /**
-     * Call-back triggered by the arrival of a new message
-     */
-    void on_message(websocketpp::connection_hdl hdl, message_ptr msg);
-
-    typedef websocketpp::client<websocketpp::config::asio_client> client;
-
     std::atomic<bool>   running;
-    client m_endpoint;
-    client::connection_ptr con;
-    std::string        subName;
-    std::string        subBody;
-    std::string        url;
-    std::promise<bool> startFlag;
-    std::future<bool>  futureStart;
-    std::promise<bool> stopFlag;
-    std::future<bool>  futureStop;
+    ASIOClient          m_endpoint;
+    ASIOClient::ConnPtr con;
+    std::string         subName;
+    std::string         subBody;
+    std::string         hello;
+    std::string         url;
+    std::promise<bool>  startFlag;
+    std::future<bool>   futureStart;
+    std::promise<bool>  stopFlag;
+    std::future<bool>   futureStop;
 
 };
 

--- a/src/ClientUtils.cpp
+++ b/src/ClientUtils.cpp
@@ -6,6 +6,7 @@
 #include <io_thread.h>
 
 #include <fstream>
+#include <sstream>
 #include <SimpleJSON.h>
 
 namespace

--- a/src/OpenConnections.cpp
+++ b/src/OpenConnections.cpp
@@ -1,5 +1,4 @@
 #include <OpenConnections.h>
-#include <OpenConnections.h>
 
 void OpenConnectionsList::Add(SubscriptionHandler::RequestHandle hdl) {
     hdls.emplace_back(hdl);

--- a/src/WebSocketPP.h
+++ b/src/WebSocketPP.h
@@ -1,0 +1,34 @@
+#ifndef CPPWEBSOCKETRESPONSEREQUEST_WEBSOCKETPP_H
+#define CPPWEBSOCKETRESPONSEREQUEST_WEBSOCKETPP_H
+
+#include <CPPWSRRWraper.h>
+
+#include <websocketpp/config/asio_no_tls.hpp>
+#include <websocketpp/server.hpp>
+#include <websocketpp/client.hpp>
+#include <websocketpp/config/asio_client.hpp>
+#include <memory>
+#include <boost/asio.hpp>
+
+using WebServer = websocketpp::server<websocketpp::config::asio>;
+using WebConnHdl = websocketpp::connection_hdl;
+using WebClient = websocketpp::client<websocketpp::config::asio_client>;
+using WebIOService = boost::asio::io_service;
+
+namespace  {
+    inline WebServer& ToWeb(Server& s) { return *reinterpret_cast<WebServer*>(s.underlying);}
+    inline WebServer* ToWeb(Server* s) { return reinterpret_cast<WebServer*>(s->underlying);}
+    inline WebConnHdl& ToWeb(ConnectHdl& c) { return reinterpret_cast<WebConnHdl&>(c.hdl);}
+    inline WebClient& ToWeb(ASIOClient& c) { return *reinterpret_cast<WebClient*>(c.underlying);}
+    inline WebClient::connection_ptr ToWeb(ASIOClient::ConnPtr& c) {
+        return reinterpret_pointer_cast<WebClient::connection_ptr::element_type>(c);
+    }
+    inline WebIOService& ToWeb(IOService& s) { return *reinterpret_cast<WebIOService*>(s.underlying); }
+    inline WebIOService* ToWeb(IOService* s) { return reinterpret_cast<WebIOService*>(s->underlying); }
+
+    inline ConnectHdl MakeWrapper(const WebConnHdl& c) { return ConnectHdl {.hdl = c}; }
+    inline ASIOClient::ConnPtr MakeWrapper(const WebClient::connection_ptr & webPtr) {
+        return ASIOClient::ConnPtr (webPtr);
+    }
+}
+#endif

--- a/src/Wraper.cpp
+++ b/src/Wraper.cpp
@@ -1,0 +1,28 @@
+//
+// Created by lhumphreys on 11/09/2020.
+//
+
+#include <CPPWSRRWraper.h>
+#include "WebSocketPP.h"
+
+Server::Server() {
+    this->underlying = new WebServer;
+}
+Server::~Server() {
+    delete (WebServer*) this->underlying;
+}
+
+ASIOClient::ASIOClient() {
+    this->underlying = new WebClient ;
+}
+
+ASIOClient::~ASIOClient() {
+    delete (WebClient*) this->underlying;
+}
+
+IOService::IOService() {
+    this->underlying = new WebIOService;
+}
+IOService::~IOService() {
+    delete (WebIOService*) this->underlying;
+}

--- a/src/io_thread.cpp
+++ b/src/io_thread.cpp
@@ -1,6 +1,6 @@
 #include "io_thread.h"
 #include <iostream>
-#include <logger.h>
+#include "WebSocketPP.h"
 
 IOThread::IOThread()
    : io_thread(&IOThread::IOLoop, this)
@@ -12,7 +12,7 @@ IOThread::~IOThread() {
     Stop();
 }
 void IOThread::Stop() {
-    io_service.stop();
+    ToWeb(io_service).stop();
     io_thread.join();
 }
 
@@ -24,7 +24,7 @@ std::shared_ptr<ReqSvrRequest> IOThread::Request(
     auto req =
         std::make_shared<ReqSvrRequest>(requestName, jsonData);
 
-    PostTask([=] () -> void {
+    PostTask([this, uri, req] () -> void {
         this->requestClient.newConnection(uri, req);
     });
 
@@ -32,11 +32,11 @@ std::shared_ptr<ReqSvrRequest> IOThread::Request(
 }
 
 void IOThread::IOLoop() {
-    boost::asio::io_service::work work(io_service);
-    io_service.run();
+    boost::asio::io_service::work work(ToWeb(io_service));
+    ToWeb(io_service).run();
 }
 
 void IOThread::PostTask(const IPostable::Task &t) {
-    io_service.post(t);
+    ToWeb(io_service).post(t);
 }
      


### PR DESCRIPTION
The request server has been re-worked to stop leaking boost and
websocketpp into the global namespace. This greatly improves compilation
times for applications, and anyone wanting raw performance should be
using the underlying library in the first place.